### PR TITLE
Update ClinVar b37 to 20230218

### DIFF
--- a/twe_vep_config_v1.0.3.json
+++ b/twe_vep_config_v1.0.3.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh37",
         "assay":"TWE",
-        "config_version": "1.0.2"
+        "config_version": "1.0.3"
     },
         "vep_resources":{
         "vep_docker":"file-G8V2Vz0433Gp5bYPF2f6vg9X",
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-GKzB0bQ44F7xZ0k78vGzxqVK",
-          "index_id":"file-GKzB0bQ44F7p86Yq88jxy800"
+          "file_id":"file-GPpBzX84fk5P3qBG9vXF9g5J",
+          "index_id":"file-GPpFyKj4gKB6ZkKyYyk238zX"
           }
         ]
       },
@@ -151,3 +151,4 @@
         "STRAND"
     ]
   }
+  


### PR DESCRIPTION
Change the config version in file ID by `git mv twe_vep_config_v1.0.2.json twe_vep_config_v1.0.3.json`. Then made the changes below:
- change config version from 1.0.2 to 1.0.3
- update the ClinVar file ID and index ID

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_TWE_config/6)
<!-- Reviewable:end -->
