### PR TITLE
Clinvar v1.1.0 -> v1.1.1

### DIFF
--- a/twe_vep_config_v1.1.1.json
+++ b/twe_vep_config_v1.1.1.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh37",
         "assay":"TWE",
-        "config_version": "1.1.0"
+        "config_version": "1.1.1"
     },
         "vep_resources":{
         "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-GPpBzX84fk5P3qBG9vXF9g5J",
-          "index_id":"file-GPpFyKj4gKB6ZkKyYyk238zX"
+          "file_id":"file-GQ9X2z844610JY75Yk6Jg1qz",
+          "index_id":"file-GQ9X6jQ43KV1Y6Zzv0y6JPJ3"
           }
         ]
       },


### PR DESCRIPTION
updated config version from v1.1.0 to v1.1.1; updated clinvar annotation version in config to 20230311

See https://cuhbioinformatics.atlassian.net/wiki/spaces/RD/pages/2886959133/230405+-+VEP+TWE+Config+file+v1.1.1 for testing details

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_TWE_config/8)
<!-- Reviewable:end -->
