### PR TITLE
Update ClinVar b37 to 20230416

### DIFF
--- a/twe_vep_config_v1.1.2.json
+++ b/twe_vep_config_v1.1.2.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh37",
         "assay":"TWE",
-        "config_version": "1.1.1"
+        "config_version": "1.1.2"
     },
         "vep_resources":{
         "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-GQ9X2z844610JY75Yk6Jg1qz",
-          "index_id":"file-GQ9X6jQ43KV1Y6Zzv0y6JPJ3"
+          "file_id":"file-GQzBBpj4jJkp94yG3yBbJyV6",
+          "index_id":"file-GQzBGF840vgp94yG3yBbJyk7"
           }
         ]
       },


### PR DESCRIPTION
Change the config version in file ID by `git mv twe_vep_config_v1.1.1.json twe_vep_config_v1.1.2.json`. Then made the changes below:

- change config version from v1.1.1 to v1.1.2
- update the ClinVar file ID and index ID

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_TWE_config/9)
<!-- Reviewable:end -->
