### PR TITLE
Update HGMD b37 to 2023.1

### DIFF
--- a/twe_vep_config_v1.1.3.json
+++ b/twe_vep_config_v1.1.3.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh37",
         "assay":"TWE",
-        "config_version": "1.1.2"
+        "config_version": "1.1.3"
     },
         "vep_resources":{
         "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
@@ -79,8 +79,8 @@
         "required_fields":"HGMD,HGMD_PHEN,HGMD_CLASS,HGMD_RANKSCORE",
         "resource_files": [
           {
-          "file_id": "file-G8Ybxg84jKXFbV938vYY088Q",
-          "index_id": "file-G8YbxgQ4jKX2z9Jb16gj4Qpk"
+          "file_id": "file-GVKGk184jzBzGB4kkXp62GzK",
+          "index_id": "file-GVKGk404jzByPV0X4FjpQJZP"
           }
         ]
       }


### PR DESCRIPTION
Change the config version in file ID by `git mv twe_vep_config_v1.1.2.json twe_vep_config_v1.1.3.json`. Then made the changes below:

- change config version from v1.1.2 to v1.1.3
- update the HGMD file ID and index ID to 2023.1