### PR TITLE
update twe_config_1.1.6

### DIFF
--- a/twe_vep_config_v1.1.6.json
+++ b/twe_vep_config_v1.1.6.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh37",
         "assay":"TWE",
-        "config_version": "1.1.5"
+        "config_version": "1.1.6"
     },
         "vep_resources":{
         "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-GXpQkgQ4Xb45Q36644FY48qk",
-          "index_id":"file-GXpQpY04qqK5pK0z04k6175B"
+          "file_id":"file-GYVX4g04J1YZ1VKg85Yqjvy9",
+          "index_id":"file-GYVX6x84xvQYxf70PGj6PKZZ"
           }
         ]
       },


### PR DESCRIPTION
Changes:

- rename filename with `git mv` to increase version from 1.1.5 to 1.1.6
- update the config_version within the file from 1.1.5 to 1.1.6
- Update Clinvar file id and index id for August version 20230819

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_TWE_config/15)
<!-- Reviewable:end -->
