### PR TITLE
Update to include latest ClinVar b37 annotation files

### DIFF
--- a/twe_vep_config_v1.1.7.json
+++ b/twe_vep_config_v1.1.7.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh37",
         "assay":"TWE",
-        "config_version": "1.1.6"
+        "config_version": "1.1.7"
     },
         "vep_resources":{
         "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-GYVX4g04J1YZ1VKg85Yqjvy9",
-          "index_id":"file-GYVX6x84xvQYxf70PGj6PKZZ"
+          "file_id":"file-GZ41Z7Q4X1V62XQ7KZK0Z6Q3",
+          "index_id":"file-GZ41bKQ43Bx117ypXj85VkX6"
           }
         ]
       },


### PR DESCRIPTION
Updated to reference ClinVar version 20230917 b37 file-ids

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_TWE_config/16)
<!-- Reviewable:end -->
