### PR TITLE
Update Clinvar to version 20231112

### DIFF
--- a/twe_vep_config_v1.1.10.json
+++ b/twe_vep_config_v1.1.10.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh37",
         "assay":"TWE",
-        "config_version": "1.1.9"
+        "config_version": "1.1.10"
     },
         "vep_resources":{
         "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-GZgBGjj4x23k82f7kp98Vj8Y",
-          "index_id":"file-GZgBJBQ4QjP89VfXgG6Xz7X1"
+          "file_id":"file-GbJfX5Q4b1zB3x12JXk57zyv",
+          "index_id":"file-GbJfX7j4b1z4zjBYJ6KvJ2XF"
           }
         ]
       },


### PR DESCRIPTION
Changes:

- updated `config_version` from v1.1.9 to v1.1.10
- updated Clinvar `file_id` and `index_id` with version 20231112

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_TWE_config/21)
<!-- Reviewable:end -->
