### PR TITLE
Update eggd VEP config for TWE 1.1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ This json file provides information about annotations,plugins, required fields a
   * Homo_sapiens.GRCh37.dna.toplevel.fa.gz.gzi
   * hs37d5.fasta-index.tar.gz
 * Custom Annotation sources:
-  * clinvar_20240317_GRCh37.vcf.gz
+  * clinvar_20240407_GRCh37.vcf.gz
   * gnomad.genomes.r2.1.1.sites.all.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz
   * gnomad.exomes.r2.1.1.sites.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz
   * TWE_POPAF_N500_chr1-22_220413.vcf.gz
-  * HGMD_Pro_2023.4_hg19.vcf.gz
+  * HGMD_Pro_2024.1_hg19.vcf.gz
 * Plugin annotations:
   * REVEL (version May 2022)
     * revel_b37.tsv.gz

--- a/twe_vep_config_v1.1.15.json
+++ b/twe_vep_config_v1.1.15.json
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-Ggv012Q4xy8GZpQY0Gz72vKJ",
-          "index_id":"file-Ggv03804qk96Yk0zv0jj147x"
+          "file_id":"file-GjKJpy0460YKpKYJ7F4k0Yyv",
+          "index_id":"file-GjKJq9Q43BbXqyYkPQ9ZBZx5"
           }
         ]
       },
@@ -79,8 +79,8 @@
         "required_fields":"HGMD,HGMD_PHEN,HGMD_CLASS,HGMD_RANKSCORE",
         "resource_files": [
           {
-          "file_id": "file-GfY7K1j4ZZKGygB1BfKVx8fv",
-          "index_id": "file-GfY7K5Q4ZZKJfx60FVFK14kq"
+          "file_id": "file-GjKPk3j4ZZKBxVx7yQ5BJ9Gz",
+          "index_id": "file-GjKPk4Q4ZZK8J493JPK33yj2"
           }
         ]
       }


### PR DESCRIPTION
renamed:    twe_vep_config_v1.1.14.json -> twe_vep_config_v1.1.15.json

Update config version from "config_version": "1.1.14" to "config_version": "1.1.15"

Update the ClinVar annotation reference file source to 20240407 as below:
- "file_id": file-Ggv012Q4xy8GZpQY0Gz72vKJ to file-GjKJpy0460YKpKYJ7F4k0Yyv
- "index_id":file-Ggv03804qk96Yk0zv0jj147x to file-GjKJq9Q43BbXqyYkPQ9ZBZx5

Update the HGMD annotation reference file source to 2024.1 as below:
- “file_id”:file-GfY7K1j4ZZKGygB1BfKVx8fv to file-GjKPk3j4ZZKBxVx7yQ5BJ9Gz
- “index_id”:file-GfY7K5Q4ZZKJfx60FVFK14kq to file-GjKPk4Q4ZZK8J493JPK33yj2

README was updated to reference the correct file versions for the updated ClinVar file and HGMD file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_TWE_config/27)
<!-- Reviewable:end -->
