### PR TITLE
update twe vep config GRCh38 and readme to recent HGMD38 and Clinvar b38

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ This json file provides information about annotations,plugins, required fields a
 | **reference_fai** | Homo_sapiens.GRCh37.dna.toplevel.fa.gz.fai | Homo_sapiens.GRCh38.dna.toplevel.fa.gz.fai |
 | **reference_gzi** | Homo_sapiens.GRCh37.dna.toplevel.fa.gz.gzi | Homo_sapiens.GRCh38.dna.toplevel.fa.gz.gzi |
 | **ref_bcftools** | hs37d5.fasta-index.tar.gz | GRCh38_GIABv3_no_alt_analysis_set_maskedGRC_decoys_MAP2K3_KMT2C_KCNJ18_noChr.fasta-index.tar.gz |
-| **ClinVar** | clinvar_20250415_GRCh37.vcf.gz | clinvar_20250115_GRCh38.vcf.gz | clinvar_20250115_GRCh38.vcf.gz |
+| **ClinVar** | clinvar_20250415_GRCh37.vcf.gz | clinvar_20250415_GRCh38.vcf.gz | clinvar_20250415_GRCh38.vcf.gz |
 | **gnomAD genomes** | gnomad.genomes.r2.1.1.sites.all.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.genomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
 | **gnomAD exomes** | gnomad.exomes.r2.1.1.sites.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.exomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
 | **CEN** | - | CEN38_POPAF_chr1-22_240503.vcf.gz |
 | **TWE** | TWE_POPAF_N500_chr1-22_220413.vcf.gz | TWE38_POPAF_chr1-22_241126.vcf.gz |
 | **Medicover** | - | Medicover38_POPAF_chr1-22_241125.vcf.gz |
-| **HGMD** | HGMD_Pro_2025.1_hg19.vcf.gz | HGMD_Pro_2024.4_hg38.vcf.gz |
+| **HGMD** | HGMD_Pro_2025.1_hg19.vcf.gz | HGMD_Pro_2025.1_hg38.vcf.gz |
 | **REVEL** | revel_b37.tsv.gz (version May 2022) | revel_b38.tsv.gz (version May 2022)
 | **CADD** | cadd_whole_genome_SNVs_GRCh37.tsv.gz, gnomad.genomes.r2.1.1.indel.tsv.gz, InDels_GRCh37.tsv.gz | cadd_1.7_b38_whole_genome_SNVs.tsv.gz,cadd.1.7.b38.gnomad.genomes.r4.0.indel.tsv.gz |
 | **SpliceAI** | spliceai_scores.masked.snv.hg19.vcf.gz, spliceai_scores.masked.indel.hg19.vcf.gz | spliceai_scores.masked.snv.hg38.vcf.gz,spliceai_scores.masked.indel.hg38.vcf.gz |

--- a/twe_vep_config_GRCh38_v1.0.1.json
+++ b/twe_vep_config_GRCh38_v1.0.1.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh38",
         "assay":"TWE",
-        "config_version": "1.0.0"
+        "config_version": "1.0.1"
     },
         "vep_resources":{
         "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-Gy72J784jBjZxFxp32GpX6pY",
-          "index_id":"file-Gy72Q2j4XjbkP7FGQGjjjqZb"
+          "file_id":"file-J03jqf04XYKGP6b0q38724k2",
+          "index_id":"file-J03jqq841VyX8F50kjq0p858"
           }
         ]
       },
@@ -107,8 +107,8 @@
         "required_fields":"HGMD,HGMD_PHEN,HGMD_CLASS,HGMD_RANKSCORE",
         "resource_files": [
           {
-          "file_id": "file-Gy7pJzj41kgFgbYjBKyPg378",
-          "index_id": "file-Gy7pKY841kgFgbYjBKyPg389"
+          "file_id": "file-J03qfBQ41kg39PFXF32p46QB",
+          "index_id": "file-J03qfVj41kg0y9qFp5JzV5q0"
           }
         ]
       }


### PR DESCRIPTION
Changes:
update ClinVar b38 to 20250415
update HGMD38 to 2025.1
Rename twe vep config GRCh38 from v1.0.0 to v1.0.1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_TWE_config/44)
<!-- Reviewable:end -->
