### PR TITLE
Update to twe_vep_config_GRCh38_v1.1.0.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This json file provides information about annotations,plugins, required fields a
 | **reference_fai** | Homo_sapiens.GRCh37.dna.toplevel.fa.gz.fai | Homo_sapiens.GRCh38.dna.toplevel.fa.gz.fai |
 | **reference_gzi** | Homo_sapiens.GRCh37.dna.toplevel.fa.gz.gzi | Homo_sapiens.GRCh38.dna.toplevel.fa.gz.gzi |
 | **ref_bcftools** | hs37d5.fasta-index.tar.gz | GRCh38_GIABv3_no_alt_analysis_set_maskedGRC_decoys_MAP2K3_KMT2C_KCNJ18_noChr.fasta-index.tar.gz |
-| **ClinVar** | clinvar_20250415_GRCh37.vcf.gz | clinvar_20250415_GRCh38.vcf.gz | clinvar_20250415_GRCh38.vcf.gz |
+| **ClinVar** | clinvar_20250415_GRCh37.vcf.gz | clinvar_20250415_GRCh38.vcf.gz |
 | **gnomAD genomes** | gnomad.genomes.r2.1.1.sites.all.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.genomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
 | **gnomAD exomes** | gnomad.exomes.r2.1.1.sites.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.exomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
 | **CEN** | - | CEN38_POPAF_chr1-22_240503.vcf.gz |
@@ -31,8 +31,8 @@ This json file provides information about annotations,plugins, required fields a
 | **REVEL** | revel_b37.tsv.gz (version May 2022) | revel_b38.tsv.gz (version May 2022)
 | **CADD** | cadd_whole_genome_SNVs_GRCh37.tsv.gz, gnomad.genomes.r2.1.1.indel.tsv.gz, InDels_GRCh37.tsv.gz | cadd_1.7_b38_whole_genome_SNVs.tsv.gz,cadd.1.7.b38.gnomad.genomes.r4.0.indel.tsv.gz |
 | **SpliceAI** | spliceai_scores.masked.snv.hg19.vcf.gz, spliceai_scores.masked.indel.hg19.vcf.gz | spliceai_scores.masked.snv.hg38.vcf.gz,spliceai_scores.masked.indel.hg38.vcf.gz |
-| **IncludeVariant** | GRCh37_inclusion_list_v1.0.1.vcf.gz | - |
-| **ExcludeVariant** | GRCh37_optimised_filtering_excluded_variants_v1.0.1.vcf.gz | - |
+| **IncludeVariant** | GRCh37_inclusion_list_v1.0.1.vcf.gz | GRCh38_inclusion_list_v1.0.0.vcf.gz |
+| **ExcludeVariant** | GRCh37_optimised_filtering_excluded_variants_v1.0.1.vcf.gz | GRCh38_exclusion_list_v1.0.1.vcf.gz |
 
 
 ## Notes

--- a/twe_vep_config_GRCh38_v1.1.0.json
+++ b/twe_vep_config_GRCh38_v1.1.0.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh38",
         "assay":"TWE",
-        "config_version": "1.0.1"
+        "config_version": "1.1.0"
     },
         "vep_resources":{
         "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
@@ -109,6 +109,34 @@
           {
           "file_id": "file-J03qfBQ41kg39PFXF32p46QB",
           "index_id": "file-J03qfVj41kg0y9qFp5JzV5q0"
+          }
+        ]
+      },
+      {
+        "name": "ExcludeVariant",
+        "type": "vcf",
+        "annotation_type": "exact",
+        "force_coordinates": "0",
+        "vcf_fields": "ExcludeList",
+        "required_fields":"ExcludeVariant_ExcludeList",
+        "resource_files": [
+          {
+          "file_id":"file-J08F84j4z6jBfYgX5VJYYP5q",
+          "index_id":"file-J08F86Q4z6j6bP1pBFBJxJ7q"
+          }
+        ]
+      },
+      {
+        "name": "IncludeVariant",
+        "type": "vcf",
+        "annotation_type": "exact",
+        "force_coordinates": "0",
+        "vcf_fields": "IncludeList",
+        "required_fields":"IncludeVariant_IncludeList",
+        "resource_files": [
+          {
+          "file_id":"file-J08F8Fj4z6j4PPVyJ0qv5b4P",
+          "index_id":"file-J08F8Gj4z6j02Jz1Zj9XfvXf"
           }
         ]
       }


### PR DESCRIPTION
- Include custom annotation source, GRCh38_exclusion_list_v1.0.1.vcf.gz to tag variants for downstream removal in the eggd_optimised_filtering app.
- Include custom annotation source, GRCh38_inclusion_list_v1.0.0.vcf.gz to tag variants for downstream removal in the eggd_optimised_filtering app.
- Update the README:
  - Include the new annotation files.
  - Delete the duplicate annotation of "clinvar_20250415_GRCh38.vcf.gz |"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_TWE_config/45)
<!-- Reviewable:end -->
