### PR TITLE
NG-786 vep_config_GRCh38_v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ This json file provides information about annotations,plugins, required fields a
 | **gnomAD exomes** | gnomad.exomes.r2.1.1.sites.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.exomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
 | **CEN** | - | CEN38_POPAF_chr1-22_240503.vcf.gz |
 | **TWE** | TWE_POPAF_N500_chr1-22_220413.vcf.gz | TWE38_POPAF_chr1-22_241126.vcf.gz |
-| **Medicover** | - | Medicover38_POPAF_chr1-22_241125.vcf.gz |
 | **HGMD** | HGMD_Pro_2025.1_hg19.vcf.gz | HGMD_Pro_2025.3_hg38.vcf.gz |
 | **REVEL** | revel_b37.tsv.gz (version May 2022) | revel_b38.tsv.gz (version May 2022)
 | **CADD** | cadd_whole_genome_SNVs_GRCh37.tsv.gz, gnomad.genomes.r2.1.1.indel.tsv.gz, InDels_GRCh37.tsv.gz | cadd_1.7_b38_whole_genome_SNVs.tsv.gz,cadd.1.7.b38.gnomad.genomes.r4.0.indel.tsv.gz |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This json file provides information about annotations,plugins, required fields a
 | **gnomAD genomes** | gnomad.genomes.r2.1.1.sites.all.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.genomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
 | **gnomAD exomes** | gnomad.exomes.r2.1.1.sites.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.exomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
 | **TWE** | TWE_POPAF_N500_chr1-22_220413.vcf.gz | - |
-| **varstore** | - | 260115_variant_store_GRCh38_WES_v1.vcf.gz
+| **CEN_varstore** | - | 260115_variant_store_GRCh38_WES_v1.vcf.gz
 | **HGMD** | HGMD_Pro_2025.1_hg19.vcf.gz | HGMD_Pro_2025.3_hg38.vcf.gz |
 | **REVEL** | revel_b37.tsv.gz (version May 2022) | revel_b38.tsv.gz (version May 2022)
 | **CADD** | cadd_whole_genome_SNVs_GRCh37.tsv.gz, gnomad.genomes.r2.1.1.indel.tsv.gz, InDels_GRCh37.tsv.gz | cadd_1.7_b38_whole_genome_SNVs.tsv.gz,cadd.1.7.b38.gnomad.genomes.r4.0.indel.tsv.gz |

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ This json file provides information about annotations,plugins, required fields a
 | **ClinVar** | clinvar_20250415_GRCh37.vcf.gz | clinvar_20260208_GRCh38.vcf.gz |
 | **gnomAD genomes** | gnomad.genomes.r2.1.1.sites.all.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.genomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
 | **gnomAD exomes** | gnomad.exomes.r2.1.1.sites.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.exomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
-| **CEN** | - | CEN38_POPAF_chr1-22_240503.vcf.gz |
-| **TWE** | TWE_POPAF_N500_chr1-22_220413.vcf.gz | TWE38_POPAF_chr1-22_241126.vcf.gz |
+| **TWE** | TWE_POPAF_N500_chr1-22_220413.vcf.gz | - |
+| **varstore** | - | 260115_variant_store_GRCh38_WES_v1.vcf.gz
 | **HGMD** | HGMD_Pro_2025.1_hg19.vcf.gz | HGMD_Pro_2025.3_hg38.vcf.gz |
 | **REVEL** | revel_b37.tsv.gz (version May 2022) | revel_b38.tsv.gz (version May 2022)
 | **CADD** | cadd_whole_genome_SNVs_GRCh37.tsv.gz, gnomad.genomes.r2.1.1.indel.tsv.gz, InDels_GRCh37.tsv.gz | cadd_1.7_b38_whole_genome_SNVs.tsv.gz,cadd.1.7.b38.gnomad.genomes.r4.0.indel.tsv.gz |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This json file provides information about annotations,plugins, required fields a
 | **reference_fai** | Homo_sapiens.GRCh37.dna.toplevel.fa.gz.fai | Homo_sapiens.GRCh38.dna.toplevel.fa.gz.fai |
 | **reference_gzi** | Homo_sapiens.GRCh37.dna.toplevel.fa.gz.gzi | Homo_sapiens.GRCh38.dna.toplevel.fa.gz.gzi |
 | **ref_bcftools** | hs37d5.fasta-index.tar.gz | GRCh38_GIABv3_no_alt_analysis_set_maskedGRC_decoys_MAP2K3_KMT2C_KCNJ18_noChr.fasta-index.tar.gz |
-| **ClinVar** | clinvar_20250415_GRCh37.vcf.gz | clinvar_20251208_GRCh38.vcf.gz |
+| **ClinVar** | clinvar_20250415_GRCh37.vcf.gz | clinvar_20260208_GRCh38.vcf.gz |
 | **gnomAD genomes** | gnomad.genomes.r2.1.1.sites.all.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.genomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
 | **gnomAD exomes** | gnomad.exomes.r2.1.1.sites.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.exomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
 | **CEN** | - | CEN38_POPAF_chr1-22_240503.vcf.gz |

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ This json file provides information about annotations,plugins, required fields a
 | **ClinVar** | clinvar_20250415_GRCh37.vcf.gz | clinvar_20260208_GRCh38.vcf.gz |
 | **gnomAD genomes** | gnomad.genomes.r2.1.1.sites.all.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.genomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
 | **gnomAD exomes** | gnomad.exomes.r2.1.1.sites.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.exomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
-| **TWE** | TWE_POPAF_N500_chr1-22_220413.vcf.gz | - |
-| **CEN_varstore** | - | 260115_variant_store_GRCh38_WES_v1.vcf.gz
+| **TWE** | TWE_POPAF_N500_chr1-22_220413.vcf.gz | 260115_variant_store_GRCh38_WES_v1.vcf.gz |
+| **CEN** | - | 260115_variant_store_GRCh38_WES_v1.vcf.gz
 | **HGMD** | HGMD_Pro_2025.1_hg19.vcf.gz | HGMD_Pro_2025.3_hg38.vcf.gz |
 | **REVEL** | revel_b37.tsv.gz (version May 2022) | revel_b38.tsv.gz (version May 2022)
 | **CADD** | cadd_whole_genome_SNVs_GRCh37.tsv.gz, gnomad.genomes.r2.1.1.indel.tsv.gz, InDels_GRCh37.tsv.gz | cadd_1.7_b38_whole_genome_SNVs.tsv.gz,cadd.1.7.b38.gnomad.genomes.r4.0.indel.tsv.gz |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This json file provides information about annotations,plugins, required fields a
 | **CADD** | cadd_whole_genome_SNVs_GRCh37.tsv.gz, gnomad.genomes.r2.1.1.indel.tsv.gz, InDels_GRCh37.tsv.gz | cadd_1.7_b38_whole_genome_SNVs.tsv.gz,cadd.1.7.b38.gnomad.genomes.r4.0.indel.tsv.gz |
 | **SpliceAI** | spliceai_scores.masked.snv.hg19.vcf.gz, spliceai_scores.masked.indel.hg19.vcf.gz | spliceai_scores.masked.snv.hg38.vcf.gz,spliceai_scores.masked.indel.hg38.vcf.gz |
 | **IncludeVariant** | GRCh37_inclusion_list_v1.0.1.vcf.gz | GRCh38_inclusion_list_v1.0.0.vcf.gz |
-| **ExcludeVariant** | GRCh37_optimised_filtering_excluded_variants_v1.0.1.vcf.gz | GRCh38_exclusion_list_v1.1.0.vcf.gz |
+| **ExcludeVariant** | GRCh37_optimised_filtering_excluded_variants_v1.0.1.vcf.gz | GRCh38_exclusion_list_v1.2.0.vcf.gz |
 
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This json file provides information about annotations,plugins, required fields a
 | **SpliceAI** | spliceai_scores.masked.snv.hg19.vcf.gz, spliceai_scores.masked.indel.hg19.vcf.gz | spliceai_scores.masked.snv.hg38.vcf.gz,spliceai_scores.masked.indel.hg38.vcf.gz |
 | **IncludeVariant** | GRCh37_inclusion_list_v1.0.1.vcf.gz | GRCh38_inclusion_list_v1.0.0.vcf.gz |
 | **ExcludeVariant** | GRCh37_optimised_filtering_excluded_variants_v1.0.1.vcf.gz | GRCh38_exclusion_list_v1.2.0.vcf.gz |
+| **Prev_Interpret** | - | 260304_inca_germline_GRCh38.vcf.gz
 
 
 ## Notes

--- a/twe_vep_config_GRCh38_v1.1.9.json
+++ b/twe_vep_config_GRCh38_v1.1.9.json
@@ -71,20 +71,6 @@
         ]
       },
       {
-        "name": "Medicover",
-        "type": "vcf",
-        "annotation_type": "exact",
-        "force_coordinates": "0",
-        "vcf_fields": "AF,AC_Hom,AC_Het,AN",
-        "required_fields":"Medicover_AF,Medicover_AC_Hom,Medicover_AC_Het,Medicover_AN",
-        "resource_files": [
-          {
-          "file_id": "file-Gx2KV804Pf00Bj3bkXxvf7qk",
-          "index_id": "file-Gx2KVj04Pf09Jq32pbbxyyb3"
-          }
-        ]
-      },
-      {
         "name": "HGMD",
         "type": "vcf",
         "annotation_type": "exact",

--- a/twe_vep_config_GRCh38_v1.1.9.json
+++ b/twe_vep_config_GRCh38_v1.1.9.json
@@ -111,6 +111,20 @@
           "index_id":"file-J08F8Gj4z6j02Jz1Zj9XfvXf"
           }
         ]
+      },
+      {
+        "name": "Prev_Interpret",
+        "type": "vcf",
+        "annotation_type": "exact",
+        "force_coordinates": "0",
+        "vcf_fields": "LATEST_GERMLINE,TOTAL_GERMLINE,LATEST_DATE,LATEST_SAMPLE_ID,AGGREGATED_HGVS",
+        "required_fields":"Prev_Interpret_LATEST_GERMLINE,Prev_Interpret_TOTAL_GERMLINE,Prev_Interpret_LATEST_DATE,Prev_Interpret_LATEST_SAMPLE_ID,Prev_Interpret_AGGREGATED_HGVS",
+        "resource_files": [
+          {
+          "file_id":"file-J6Z4Ypj4bq82BKkk4xy1Jvfv",
+          "index_id":"file-J6Z4Yv04bq85BkVGkfvXk2Vx"
+          }
+        ]
       }
     ],
     "plugins": [

--- a/twe_vep_config_GRCh38_v1.1.9.json
+++ b/twe_vep_config_GRCh38_v1.1.9.json
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-J4zzyV04vjqFKBJp1vVF1p21",
-          "index_id":"file-J4zzyXj43Xkyg01fvJ4bkyYp"
+          "file_id":"file-J69K6x04Y09KjB575Jq8BQ3p",
+          "index_id":"file-J69K7J04Kb05P4F8qy45fY5G"
           }
         ]
       },

--- a/twe_vep_config_GRCh38_v1.1.9.json
+++ b/twe_vep_config_GRCh38_v1.1.9.json
@@ -93,8 +93,8 @@
         "required_fields":"ExcludeVariant_ExcludeList",
         "resource_files": [
           {
-          "file_id":"file-J1602g84zV9kbzK3FPz9PZx3",
-          "index_id":"file-J1608Q04zV9qjKk30qX3Y176"
+          "file_id":"file-J6G9q6j4V702Q6j947jgyb0j",
+          "index_id":"file-J6G9vXQ4V70K6p2PZ0Vffgfq"
           }
         ]
       },

--- a/twe_vep_config_GRCh38_v1.1.9.json
+++ b/twe_vep_config_GRCh38_v1.1.9.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh38",
         "assay":"TWE",
-        "config_version": "1.1.8"
+        "config_version": "1.1.9"
     },
         "vep_resources":{
         "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",

--- a/twe_vep_config_GRCh38_v1.1.9.json
+++ b/twe_vep_config_GRCh38_v1.1.9.json
@@ -57,30 +57,16 @@
         ]
       },
       {
-        "name": "CEN",
+        "name": "varstore",
         "type": "vcf",
         "annotation_type": "exact",
         "force_coordinates": "0",
-        "vcf_fields": "AF,AC_Hom,AC_Het,AN",
-        "required_fields":"CEN_AF,CEN_AC_Hom,CEN_AC_Het,CEN_AN",
+        "vcf_fields": "WES_v1_HET_COUNT,WES_v1_HOM_COUNT,WES_v1_AC,WES_v1_AN,WES_v1_AF",
+        "required_fields": "varstore_WES_v1_HET_COUNT,varstore_WES_v1_HOM_COUNT,varstore_WES_v1_AC,varstore_WES_v1_AN,varstore_WES_v1_AF",
         "resource_files": [
           {
-          "file_id": "file-GjpKK5Q4bxf3B581FGVZy1f5",
-          "index_id": "file-GjpKKF04bxfJqJqgz543J26g"
-          }
-        ]
-      },
-      {
-        "name": "TWE",
-        "type": "vcf",
-        "annotation_type": "exact",
-        "force_coordinates": "0",
-        "vcf_fields": "AF,AC_Hom,AC_Het,AN",
-        "required_fields":"TWE_AF,TWE_AC_Hom,TWE_AC_Het,TWE_AN",
-        "resource_files": [
-          {
-          "file_id": "file-GvzXFkj4JkPFK5VKYkjZKzzY",
-          "index_id": "file-GvzZX904JkP84BQqxvyqG4Pg"
+            "file_id": "file-J5ZVxg84XjqGjqjzyXbjK7q7",
+            "index_id": "file-J5ZVxjQ4XjqGvGypFv3Q5KKX"
           }
         ]
       },

--- a/twe_vep_config_GRCh38_v1.2.0.json
+++ b/twe_vep_config_GRCh38_v1.2.0.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh38",
         "assay":"TWE",
-        "config_version": "1.1.9"
+        "config_version": "1.2.0"
     },
         "vep_resources":{
         "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",

--- a/twe_vep_config_GRCh38_v1.2.0.json
+++ b/twe_vep_config_GRCh38_v1.2.0.json
@@ -57,7 +57,7 @@
         ]
       },
       {
-        "name": "varstore",
+        "name": "CEN_varstore",
         "type": "vcf",
         "annotation_type": "exact",
         "force_coordinates": "0",

--- a/twe_vep_config_GRCh38_v1.2.0.json
+++ b/twe_vep_config_GRCh38_v1.2.0.json
@@ -57,7 +57,7 @@
         ]
       },
       {
-        "name": "CEN_varstore",
+        "name": "TWE_varstore",
         "type": "vcf",
         "annotation_type": "exact",
         "force_coordinates": "0",

--- a/twe_vep_config_GRCh38_v1.2.0.json
+++ b/twe_vep_config_GRCh38_v1.2.0.json
@@ -71,6 +71,20 @@
         ]
       },
       {
+        "name": "CEN",
+        "type": "vcf",
+        "annotation_type": "exact",
+        "force_coordinates": "0",
+        "vcf_fields": "CEN_v1_HET_COUNT,CEN_v1_HOM_COUNT,CEN_v1_AC,CEN_v1_AN,CEN_v1_AF",
+        "required_fields":"CEN_CEN_v1_HET_COUNT,CEN_CEN_v1_HOM_COUNT,CEN_CEN_v1_AC,CEN_CEN_v1_AN,CEN_CEN_v1_AF",
+        "resource_files": [
+          {
+          "file_id":"file-J5ZVv1j4JgjX6pxb9ZpXK3Jq",
+          "index_id":"file-J5ZVv304JgjX6pxb9ZpXK3K9"
+          }
+        ]
+      },
+      {
         "name": "HGMD",
         "type": "vcf",
         "annotation_type": "exact",

--- a/twe_vep_config_GRCh38_v1.2.0.json
+++ b/twe_vep_config_GRCh38_v1.2.0.json
@@ -57,12 +57,12 @@
         ]
       },
       {
-        "name": "TWE_varstore",
+        "name": "TWE",
         "type": "vcf",
         "annotation_type": "exact",
         "force_coordinates": "0",
         "vcf_fields": "WES_v1_HET_COUNT,WES_v1_HOM_COUNT,WES_v1_AC,WES_v1_AN,WES_v1_AF",
-        "required_fields": "varstore_WES_v1_HET_COUNT,varstore_WES_v1_HOM_COUNT,varstore_WES_v1_AC,varstore_WES_v1_AN,varstore_WES_v1_AF",
+        "required_fields": "TWE_WES_v1_HET_COUNT,TWE_WES_v1_HOM_COUNT,TWE_WES_v1_AC,TWE_WES_v1_AN,TWE_WES_v1_AF",
         "resource_files": [
           {
             "file_id": "file-J5ZVxg84XjqGjqjzyXbjK7q7",


### PR DESCRIPTION
- clinvar version updated to 20260208

- “CEN” and “TWE” custom annotation sections replaced with “varstore”

- “Medicover“ custom annotation section removed

- “ExcludeVariant“ VCF IDs updated to v1.2.0

- INCA added as a new custom annotation section called “Prev_Interpret“

- version metadata + README updated

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_TWE_config/55)
<!-- Reviewable:end -->
