### PR TITLE
Updated INCA annotation for twe_vep_config_GRCh38_1.2.1.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This json file provides information about annotations,plugins, required fields a
 | **SpliceAI** | spliceai_scores.masked.snv.hg19.vcf.gz, spliceai_scores.masked.indel.hg19.vcf.gz | spliceai_scores.masked.snv.hg38.vcf.gz,spliceai_scores.masked.indel.hg38.vcf.gz |
 | **IncludeVariant** | GRCh37_inclusion_list_v1.0.1.vcf.gz | GRCh38_inclusion_list_v1.0.0.vcf.gz |
 | **ExcludeVariant** | GRCh37_optimised_filtering_excluded_variants_v1.0.1.vcf.gz | GRCh38_exclusion_list_v1.2.0.vcf.gz |
-| **Prev_Interpret** | - | 260304_inca_germline_GRCh38.vcf.gz
+| **Prev_Interpret** | - | 260323_inca_germline_GRCh38.vcf.gz |
 
 
 ## Notes

--- a/twe_vep_config_GRCh38_v1.2.1.json
+++ b/twe_vep_config_GRCh38_v1.2.1.json
@@ -135,8 +135,8 @@
         "required_fields":"Prev_Interpret_LATEST_GERMLINE,Prev_Interpret_TOTAL_GERMLINE,Prev_Interpret_LATEST_DATE,Prev_Interpret_LATEST_SAMPLE_ID,Prev_Interpret_AGGREGATED_HGVS",
         "resource_files": [
           {
-          "file_id":"file-J6Z4Ypj4bq82BKkk4xy1Jvfv",
-          "index_id":"file-J6Z4Yv04bq85BkVGkfvXk2Vx"
+          "file_id":"file-J70QX4Q4bq83VqJ9ZyX4gX6q",
+          "index_id":"file-J70QX5j4bq89QjpGzF2BxB39"
           }
         ]
       }


### PR DESCRIPTION
Changes
- INCA annotation VCF + index updated to 260323_inca_germline_GRCh38.vcf.gz
- Readme updated accordingly

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_TWE_config/57)
<!-- Reviewable:end -->
